### PR TITLE
Define get_colnames

### DIFF
--- a/diverge/binding.py
+++ b/diverge/binding.py
@@ -27,6 +27,10 @@ def read_tree(tree_file: str) -> Tree:
     raise ValueError(f"Tree file '{tree_file}' could not be parsed: {last_error}")
 
 
+def get_colnames(names):
+    return list(names)
+
+
 def load_tree_file(tree_file: str, check: bool = True) -> str:
     """Load a tree file and optionally check its validity.
     


### PR DESCRIPTION
These three classes call `get_colnames` in their `summary` property, but it is not defined or imported anywhere in the package:

- `binding.py:321` (`Gu99.summary`)
- `binding.py:961` (`Rvs.summary`)
- `binding.py:1023` (`TypeOneAnalysis.summary`)

`Gu99.__init__` assigns `self._summary_result = self.summary`, so the error fires on construction:

```python
from diverge import Gu99
Gu99("CASP.aln", "cl1.tree", "cl2.tree", cluster_name=["A", "B"])
# NameError: name 'get_colnames' is not defined
```

The calculators already return display-ready labels — `_r_names()` returns `['A/B']` — so a pass-through is enough.

With this applied, on `Tutorial/test_data`:

```
Gu99.summary   MFE Theta, MFE se, MFE r X, MFE r max, MFE z score,
               ThetaML, AlphaML, SE Theta, LRT Theta
Gu99.results   (781, 1), column 'A/B', index Position
```

Same shape and index as `Type2` on the same input.
