### PR TITLE
Include requirements.txt in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
`setup.py` reads `requirements.txt` at build time:

```python
with open("requirements.txt", "r") as f:
    REQUIRED_PACKAGES = f.read().splitlines()
```

but the file is not included in the sdist, so installing from PyPI fails:

```
$ pip install diverge --no-build-isolation
  File "<string>", line 10, in <module>
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```

Adding a `MANIFEST.in` ships it. Building from a git clone is unaffected.
