### PR TITLE
Build on macOS/clang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ __version__ = "4.1.0"
 with open("requirements.txt", "r") as f:
     REQUIRED_PACKAGES = f.read().splitlines()
 
+SRC_DIR = 'src' if sys.platform == 'win32' else 'src_linux'
+
+
 def get_extension_modules():
     """Define and return the list of extension modules."""
     common_compile_args = ['-w']
@@ -18,7 +21,7 @@ def get_extension_modules():
     extension_modules = [
         Pybind11Extension(
             f"diverge._{module}cpp",
-            sorted(glob(f'src/{module}/*.c*')),
+            sorted(glob(f'{SRC_DIR}/{module}/*.c*')),
             define_macros=common_macros,
             language='c++',
             extra_compile_args=common_compile_args,

--- a/src_linux/asym/cluster.cpp
+++ b/src_linux/asym/cluster.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <vector>
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -8,15 +9,6 @@
 #include "cluster.h"
 #include "sequence.h"
 using namespace std;
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/asym/common.h
+++ b/src_linux/asym/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:

--- a/src_linux/effective/cluster.cpp
+++ b/src_linux/effective/cluster.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <vector>
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -8,15 +9,6 @@
 #include "cluster.h"
 #include "sequence.h"
 using namespace std;
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/effective/common.h
+++ b/src_linux/effective/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:

--- a/src_linux/fdr/cluster.cpp
+++ b/src_linux/fdr/cluster.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <vector>
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -8,15 +9,6 @@
 #include "cluster.h"
 #include "sequence.h"
 using namespace std;
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/fdr/common.h
+++ b/src_linux/fdr/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:

--- a/src_linux/gu2001/cluster.cpp
+++ b/src_linux/gu2001/cluster.cpp
@@ -3,31 +3,19 @@
 #include <string>
 #include <vector>
 
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 
 #include <stdio.h>
 
-#ifndef WIN32
-#include <values.h>
-#else
 #include <float.h>
-#endif
 
 #include "cluster.h"
 #include "sequence.h"
 
 using namespace std;
 
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/gu2001/common.h
+++ b/src_linux/gu2001/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:

--- a/src_linux/gu99/cluster.cpp
+++ b/src_linux/gu99/cluster.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <vector>
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -8,15 +9,6 @@
 #include "cluster.h"
 #include "sequence.h"
 using namespace std;
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/gu99/common.h
+++ b/src_linux/gu99/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:

--- a/src_linux/rvs/cluster.cpp
+++ b/src_linux/rvs/cluster.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <vector>
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -8,15 +9,6 @@
 #include "cluster.h"
 #include "sequence.h"
 using namespace std;
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/rvs/common.h
+++ b/src_linux/rvs/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:

--- a/src_linux/type2/cluster.cpp
+++ b/src_linux/type2/cluster.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <vector>
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -8,15 +9,6 @@
 #include "cluster.h"
 #include "sequence.h"
 using namespace std;
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/type2/common.h
+++ b/src_linux/type2/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:

--- a/src_linux/typeOneAnalysis/cluster.cpp
+++ b/src_linux/typeOneAnalysis/cluster.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <string>
 #include <vector>
+#include <cmath>
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -8,15 +9,6 @@
 #include "cluster.h"
 #include "sequence.h"
 using namespace std;
-#ifndef WIN32
-#  define isfinite(x) \
-     (sizeof (x) == sizeof (float)                                            \
-      ? __finitef (x)                                                         \
-      : sizeof (x) == sizeof (double)                                         \
-      ? __finite (x) : __finitel (x))
-#else
-#define isfinite(x) _finite(x)
-#endif
 
 #if 0
 static void

--- a/src_linux/typeOneAnalysis/common.h
+++ b/src_linux/typeOneAnalysis/common.h
@@ -7,7 +7,6 @@
 #define appname "genePlei"
 
 
-#define version "V1.0"
 
 class summary_t {
 public:


### PR DESCRIPTION
The package does not build on macOS/clang. Four separate causes:

**1. `setup.py` compiles `src/`, which is MSVC-only.** Those files begin with `#define WIN32` and then use `_finite` and `__declspec(dllexport)`. This selects `src_linux` on non-Windows platforms.

**2. The `isfinite` macro.** `src_linux/*/cluster.cpp` defines it in terms of `__finitef` / `__finite` / `__finitel`, which are glibc internals. These files already do `using namespace std`, so removing the macro lets `std::isfinite` from `<cmath>` be found.

**3. `gu2001/cluster.cpp` includes `<values.h>`,** which is glibc-only. `<float.h>` was included, but only on the `WIN32` branch, so `DBL_MAX` was undeclared.

**4. `#define version "V1.0"` in `common.h`** collides with a member of the same name in pybind11's `detail/internals.h`:

```
internals.h:457:19: error: expected member name or ';' after declaration specifiers
  457 |     const uint8_t version = 1;
common.h:10:17: note: expanded from macro 'version'
```

The macro is not used anywhere, so it is removed.

Verified on macOS 15 (arm64), clang, Python 3.12, pybind11 3.x — builds clean, and on `Tutorial/test_data`:

```
Type2.results  (781, 1), column 'A/B', index Position 132..1460
```

Not addressed here: `Gu2001` compiles but prints `Error in gu2001_compute module!` at runtime on this platform.
