### PR TITLE
Export Gu99Batch

### DIFF
--- a/diverge/__init__.py
+++ b/diverge/__init__.py
@@ -11,6 +11,7 @@ __author__ = 'DIVERGE Team'
 from .binding import (
     # Core analysis classes
     Gu99,
+    Gu99Batch,
     Gu2001,
     Type2,
     Asym,


### PR DESCRIPTION
`README.md:114` and `Tutorial/User_Guide.md:271` both show:

```python
from diverge import Gu99Batch
```

but `Gu99Batch` is not re-exported from `diverge/__init__.py`, so that import raises `ImportError`. The class is defined in `binding.py`.
