### PR TITLE
Correct the tree depth error message

### DIFF
--- a/diverge/binding.py
+++ b/diverge/binding.py
@@ -34,7 +34,7 @@ def load_tree_file(tree_file: str, check: bool = True) -> str:
     
     Args:
         tree_file: Path to the tree file to load.
-        check: Whether to validate the tree structure (depth >= 3).
+        check: Whether to validate the tree structure (depth > 3).
         
     Returns:
         The tree in Newick format string, with trailing newlines removed.
@@ -80,7 +80,7 @@ def check_tree(tree: Tree) -> bool:
         ValueError: If the tree depth is less than or equal to 3.
     """
     if not check_tree_depth(tree):
-        raise ValueError(f'Tree depth is less than 3, please check your tree: {tree}')
+        raise ValueError(f'Tree depth must be greater than 3, please check your tree: {tree}')
     return True
 
 def check_tree_file(*tree_files: str) -> bool:


### PR DESCRIPTION
`check_tree_depth` returns `tree_depth > min_depth` with `min_depth=3`, so a tree of depth exactly 3 is rejected — but the message says it is "less than 3", and `load_tree_file`'s docstring says the check is `depth >= 3`.

```python
# depth 3, rejected
check_tree(Phylo.read(StringIO("((a:0.1,b:0.1):0.1,c:0.1);"), "newick"))
# ValueError: Tree depth is less than 3, please check your tree: ...
```

The `check_tree` docstring already states the rule correctly ("depth <= 3 are considered invalid"); this brings the message and the other docstring in line.
